### PR TITLE
Fix commands checker

### DIFF
--- a/MarkovIsCursed/MarkovLibrary.py
+++ b/MarkovIsCursed/MarkovLibrary.py
@@ -22,11 +22,9 @@ def start(rule_list, changed_string):
     return _out
 
 
-def check_rules(rule_list, void_char):
-    rules = rule_list.split("\n")
-    for n in range(0, len(rules)):
-        rules[n] = rules[n].split("-")
-    for s in rules:
-        if s[0].find(void_char) != -1 or s[1].find(s[0]) != -1:
+def check_rules(rule_list):
+    rules = rule_list.split(";")
+    for r in rules:
+        if len(r.split("-")) != 2:
             return False
     return True

--- a/MarkovIsCursed/UiLayout.py
+++ b/MarkovIsCursed/UiLayout.py
@@ -50,7 +50,7 @@ class Ui_MainWindow(object):
         _translate = QtCore.QCoreApplication.translate
         MainWindow.setWindowTitle(_translate("MainWindow", "НАМ"))
         self.inputBox.setPlaceholderText(_translate("MainWindow", "Входная строка"))
-        self.cmdsBox.setPlaceholderText(_translate("MainWindow", "Команды через точку с запятой"))
+        self.cmdsBox.setPlaceholderText(_translate("MainWindow", "Команды через точку с запятой. Пустые команды недопустимы."))
         self.runBtn.setText(_translate("MainWindow", "Выполнить"))
         self.outputBox.setPlaceholderText(_translate("MainWindow", "Здесь будет вывод"))
         self.clearBtn.setText(_translate("MainWindow", "Очистить вывод"))

--- a/MarkovIsCursed/main.py
+++ b/MarkovIsCursed/main.py
@@ -32,7 +32,7 @@ class App(QtWidgets.QMainWindow, Ui_MainWindow):
             self.outputBox.setText("Введите команды для выполнения!")
             return
 
-        if (check_rules(cmds, "#")):
+        if (check_rules(cmds)):
             res = start(cmds, text)
             self.outputBox.setPlainText("\n".join(res))
         else:

--- a/MarkovIsCursed/nam.ui
+++ b/MarkovIsCursed/nam.ui
@@ -25,7 +25,7 @@
     <item>
      <widget class="QPlainTextEdit" name="cmdsBox">
       <property name="placeholderText">
-       <string>Команды через точку с запятой</string>
+       <string>Команды через точку с запятой. Пустые команды недопустимы.</string>
       </property>
      </widget>
     </item>


### PR DESCRIPTION
Он не совсем понятно что именно проверял, но как минимум, заставлял всё это падать.

Сделал чтоб он проверял то что нет пустых/перегруженых команд, если нам нужны комментарии, "проверку и запуск" надо менять на "парсинг и запуск", как раз отделяя лишние куски